### PR TITLE
Use media flag from argument instead of hardcoded value

### DIFF
--- a/pyCast.py
+++ b/pyCast.py
@@ -137,8 +137,8 @@ daemon.start()
 time.sleep(2)
 
 # Get list of files of specific type, in specific directory
-pprint.pprint(glob.glob(args.directory+"/"+MEDIA_FLAG))
-filesAndPath = glob.glob(args.directory+"/"+MEDIA_FLAG)
+pprint.pprint(glob.glob(args.directory+"/"+args.media_flag))
+filesAndPath = glob.glob(args.directory+"/"+args.media_flag)
 nFiles = len(filesAndPath)
 if (nFiles==0):
     pprint.pprint("Error: No files found")


### PR DESCRIPTION
As it was set up before, the value of the argument was never used.