### PR TITLE
Sort files in non-shuffle mode

### DIFF
--- a/pyCast.py
+++ b/pyCast.py
@@ -137,8 +137,8 @@ daemon.start()
 time.sleep(2)
 
 # Get list of files of specific type, in specific directory
-pprint.pprint(glob.glob(args.directory+"/"+MEDIA_FLAG))
-filesAndPath = glob.glob(args.directory+"/"+MEDIA_FLAG)
+filesAndPath = sorted(glob.glob(args.directory + "/" + args.media_flag))
+pprint.pprint(filesAndPath)
 nFiles = len(filesAndPath)
 if (nFiles==0):
     pprint.pprint("Error: No files found")


### PR DESCRIPTION
There's no guarantee that `glob.glob` produces results in any particular order. In fact, they can completely shuffled, meaning that without actually sorted the files, one will get them in what appears to be a random order even if the "random order" argument isn't used.