### PR TITLE
Fix default value of do-random parameter

### DIFF
--- a/pyCast.py
+++ b/pyCast.py
@@ -92,7 +92,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument("--do-random", help="Pick media in dir at random, default false",
-                    action="store_false")
+                    action="store_true")
 parser.add_argument(
     "--media-flag", help="Media flag like *.JPEG or *.png", default=MEDIA_FLAG
 )


### PR DESCRIPTION
The parameter had a default value of True (store_false) when the docs indicate that it should have a default value of False (store_true).